### PR TITLE
Update credential setting for the hub

### DIFF
--- a/datasets/aster-l1t/aster-l1t-example.ipynb
+++ b/datasets/aster-l1t/aster-l1t-example.ipynb
@@ -13,7 +13,10 @@
    "id": "optional-segment",
    "metadata": {},
    "source": [
-    "### Environment setup"
+    "### Environment setup\n",
+    "\n",
+    "This notebook works with or without an API key, but you will be given more permissive access to the data with an API key.\n",
+    "The [Planetary Computer Hub](https://planetarycomputer.microsoft.com/compute) is pre-configured to include your API key."
    ]
   },
   {
@@ -28,11 +31,8 @@
     "from pystac_client import Client\n",
     "import planetary_computer as pc\n",
     "\n",
-    "# If you have a Planetary Computer API key, specify it here. This notebook\n",
-    "# will work with or without an API key, but you will be given more permissive\n",
-    "# access to data with an API key.\n",
-    "subscription_key = None\n",
-    "pc.settings.set_subscription_key(subscription_key)"
+    "# Set the environment variable PC_SDK_SUBSCRIPTION_KEY, or set it here\n",
+    "# pc.settings.set_subscription_key(<YOUR API Key>)"
    ]
   },
   {

--- a/datasets/landsat-8-c2-l2/landsat-8-c2-l2-example.ipynb
+++ b/datasets/landsat-8-c2-l2/landsat-8-c2-l2-example.ipynb
@@ -7,7 +7,10 @@
    "source": [
     "## Accessing Landsat 8 Collection 2 Level 2 data with the Planetary Computer STAC API\n",
     "\n",
-    "### Environment setup"
+    "### Environment setup\n",
+    "\n",
+    "This notebook works with or without an API key, but you will be given more permissive access to the data with an API key.\n",
+    "The [Planetary Computer Hub](https://planetarycomputer.microsoft.com/compute) is pre-configured to include your API key."
    ]
   },
   {
@@ -20,11 +23,8 @@
     "from pystac_client import Client\n",
     "import planetary_computer as pc\n",
     "\n",
-    "# If you have a Planetary Computer API key, specify it here. This notebook\n",
-    "# will work with or without an API key, but you will be given more permissive\n",
-    "# access to data with an API key.\n",
-    "subscription_key = None\n",
-    "pc.settings.set_subscription_key(subscription_key)"
+    "# Set the environment variable PC_SDK_SUBSCRIPTION_KEY, or set it here\n",
+    "# pc.settings.set_subscription_key(<YOUR API Key>)"
    ]
   },
   {

--- a/datasets/naip/naip-example.ipynb
+++ b/datasets/naip/naip-example.ipynb
@@ -7,7 +7,10 @@
    "source": [
     "## Accessing NAIP data with the Planetary Computer STAC API\n",
     "\n",
-    "### Environment setup"
+    "### Environment setup\n",
+    "\n",
+    "This notebook works with or without an API key, but you will be given more permissive access to the data with an API key.\n",
+    "The [Planetary Computer Hub](https://planetarycomputer.microsoft.com/compute) is pre-configured to include your API key."
    ]
   },
   {
@@ -20,11 +23,8 @@
     "from pystac_client import Client\n",
     "import planetary_computer as pc\n",
     "\n",
-    "# If you have a Planetary Computer API key, specify it here. This notebook\n",
-    "# will work with or without an API key, but you will be given more permissive\n",
-    "# access to data with an API key.\n",
-    "subscription_key = None\n",
-    "pc.settings.set_subscription_key(subscription_key)"
+    "# Set the environment variable PC_SDK_SUBSCRIPTION_KEY, or set it here\n",
+    "# pc.settings.set_subscription_key(<YOUR API Key>)"
    ]
   },
   {

--- a/datasets/sentinel-2-l2a/sentinel-2-l2a-example.ipynb
+++ b/datasets/sentinel-2-l2a/sentinel-2-l2a-example.ipynb
@@ -5,7 +5,10 @@
    "id": "a067106c",
    "metadata": {},
    "source": [
-    "## Accessing Sentinel-2 L2A data with the Planetary Computer STAC API\n",
+    "### Environment setup\n",
+    "\n",
+    "This notebook works with or without an API key, but you will be given more permissive access to the data with an API key.\n",
+    "The [Planetary Computer Hub](https://planetarycomputer.microsoft.com/compute) is pre-configured to include your API key.## Accessing Sentinel-2 L2A data with the Planetary Computer STAC API\n",
     "\n",
     "### Environment setup"
    ]
@@ -20,11 +23,8 @@
     "from pystac_client import Client\n",
     "import planetary_computer as pc\n",
     "\n",
-    "# If you have a Planetary Computer API key, specify it here. This notebook\n",
-    "# will work with or without an API key, but you will be given more permissive\n",
-    "# access to data with an API key.\n",
-    "subscription_key = None\n",
-    "pc.settings.set_subscription_key(subscription_key)"
+    "# Set the environment variable PC_SDK_SUBSCRIPTION_KEY, or set it here\n",
+    "# pc.settings.set_subscription_key(<YOUR API Key>)"
    ]
   },
   {


### PR DESCRIPTION
This updates the documentation to note that setting the subscription key is done automatically on the Hub.