### PR TITLE
User-facing README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Planetary Computer Examples
+
+This repository contains Jupyter Notebooks that serve as examples of using the [Microsoft Planetary Computer](https://planetarycomputer.microsoft.com) data, APIs and Hub.
+
+## Getting Started
+
+This project uses Docker to encapsulate the development environment. To set up your development
+environment, have Docker installed and run:
+
+```
+> scripts/setup
+```
+
+If you need to rebuild the images at any point, you
+can run:
+
+```
+> scripts/update
+```
+
+To run the jupyter notebook server, you can use:
+
+```
+> scripts/server
+```
+
+And browse to the URL printed in the terminal output.
+
+From there you'll be able to run all Jupyter Notebook examples.
+
+## Contributing
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Trademarks
+
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
+[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,17 @@
 # Planetary Computer Examples
 
-This repository contains Jupyter Notebooks that serve as examples of using the [Microsoft Planetary Computer](https://planetarycomputer.microsoft.com) data, APIs and Hub.
+<img src="https://planetarycomputer.microsoft.com/images/planet-sunrise-wide@1.jpg" alt="Planetary Computer" width="50%"/>
 
-## Getting Started
+Welcome to the [Planetary Computer Hub](http://planetarycomputer.microsoft.com/compute), a development environment that makes our data and APIs accessible through familiar, open-source tools, and allows users to easily scale their analyses.
 
-This project uses Docker to encapsulate the development environment. To set up your development
-environment, have Docker installed and run:
+## Examples
 
-```
-> scripts/setup
-```
+* [Aster L1T](datasets/aster-l1t/aster-l1t-example.ipynb)
+* [Landsat 8 Collection 2 Level-2](datasets/landsat-8-c2-l2/landsat-8-c2-l2-example.ipynb)
+* [Sentinel-2 Level-2A](datasets/naip/naip-example.ipynb)
+* [NAIP: National Agricultural Imagery Program](datasets/sentinel-2-l2a/sentinel-2-l2a-example.ipynb)
 
-If you need to rebuild the images at any point, you
-can run:
+## Learn More
 
-```
-> scripts/update
-```
-
-To run the jupyter notebook server, you can use:
-
-```
-> scripts/server
-```
-
-And browse to the URL printed in the terminal output.
-
-From there you'll be able to run all Jupyter Notebook examples.
-
-## Contributing
-
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
-
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
-## Trademarks
-
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
-trademarks or logos is subject to and must follow
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
-Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
-Any use of third-party trademarks or logos are subject to those third-party's policies.
+* Data Catalog: https://planetarycomputer.microsoft.com/catalog
+* Documentation: https://planetarycomputer.microsoft.com/docs/overview/about


### PR DESCRIPTION
This PR updates the README to be an index for the collection of examples. It moves the previous README to a CONTRIBUTING.md.

The motivation is to use the new README as a landing page for the Hub.