### PR TITLE
Use dashboard_link in scale-with-dask

### DIFF
--- a/quickstarts/scale-with-dask.ipynb
+++ b/quickstarts/scale-with-dask.ipynb
@@ -40,7 +40,7 @@
     "cluster = dask_gateway.GatewayCluster()\n",
     "client = cluster.get_client()\n",
     "cluster.scale(4)\n",
-    "print(cluster)"
+    "print(cluster.dashboard_link)"
    ]
   },
   {
@@ -52,7 +52,7 @@
     "\n",
     "### Open the dashboard\n",
     "\n",
-    "The [Dask Dashboard](https://docs.dask.org/en/latest/diagnostics-distributed.html) provides invaluable information on the activity of your cluster. Clicking the \"Dashboard\" link at the bottom of the cluster repr will open a new browser tab.\n",
+    "The [Dask Dashboard](https://docs.dask.org/en/latest/diagnostics-distributed.html) provides invaluable information on the activity of your cluster. Clicking the \"Dashboard\" link above will open the Dask dashboard a new browser tab.\n",
     "\n",
     "<img src=\"images/dashboard-tab.png\" width=\"50%\" alt=\"Dask Dashboard in a new tab.\"/>\n",
     "\n",
@@ -60,14 +60,8 @@
     "\n",
     "<img src=\"images/dashboard-hub.png\" width=\"50%\" alt=\"Dask Dashboard in jupyterlab.\"/>\n",
     "\n",
-    "To using the dask-labextension, copy the \"Dashboard\" address from the cluster repr, click the orange Dask logo on the lefthand navigation bar, and paste the dashboard address "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "supreme-demographic",
-   "metadata": {},
-   "source": [
+    "To using the dask-labextension, copy the \"Dashboard\" address from the cluster repr, click the orange Dask logo on the lefthand navigation bar, and paste the dashboard address \n",
+    "\n",
     "You can close your cluster, freeing up its resources, by calling `cluster.close()`."
    ]
   },
@@ -1519,7 +1513,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1533,7 +1527,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
The static site can't display widgets, so we avoid printing out the
cluster's repr HTML. But the plaintext repr doesn't have a dashboard
link.