### PR TITLE
Fix ALOS header

### DIFF
--- a/datasets/alos-dem/alos-dem-example.ipynb
+++ b/datasets/alos-dem/alos-dem-example.ipynb
@@ -5,7 +5,7 @@
    "id": "d5a49b45-2d28-4131-b617-3bb4de3399ef",
    "metadata": {},
    "source": [
-    "# Using ALOS Digital Elevation Models (DEMs) with the Planetary Computer STAC API\n",
+    "## Using ALOS Digital Elevation Models (DEMs) with the Planetary Computer STAC API\n",
     "\n",
     "The Advanced Land Observing Satellite (ALOS) is a Japanese satellite that was operational from 2006 to 2011. It generated a global digital elevation model using its PRISM panchromatic optical sensor. These data are available from the Planetary Computer as Cloud Optimized GeoTIFFs."
    ]
@@ -157,7 +157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
FYI @gadomski, we have a linting rule that notebooks have no H1s and exactly one H2, so that they fit nicely into the docs at planetarycomputer.microsoft.com/

This is why you never push straight to main :)