### PR TITLE
Add code to compare competition chip to STAC item sensing time

### DIFF
--- a/competitions/cloud-cover/additional-bands-tutorial.ipynb
+++ b/competitions/cloud-cover/additional-bands-tutorial.ipynb
@@ -46,6 +46,7 @@
     "import pandas as pd\n",
     "from pandas_path import path  # noqa\n",
     "from pathlib import Path\n",
+    "import requests\n",
     "from tqdm import tqdm\n",
     "from typing import Optional, List"
    ]
@@ -70,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "2278004c-404b-42a4-84f8-7c34a33188ef",
    "metadata": {},
    "outputs": [],
@@ -84,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "f2d2a3fb-3595-4723-a5f7-b537369180d9",
    "metadata": {},
    "outputs": [],
@@ -94,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "3d7ece16-044f-4727-b308-19c804dd45bd",
    "metadata": {},
    "outputs": [
@@ -174,7 +175,7 @@
        "4    aeaj  Chifunfu  2020-04-29T08:20:47Z  az://./train_features/aeaj"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -195,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "a1c25bd7-c4df-4650-ae49-855e4669a5f7",
    "metadata": {},
    "outputs": [],
@@ -217,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "9b511d01-fe6b-49f9-b0a9-9f6b57b55592",
    "metadata": {},
    "outputs": [],
@@ -244,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "eb918b5d-520d-4ff5-bb6d-6a1a8c4b2897",
    "metadata": {},
    "outputs": [],
@@ -275,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "83b288e0-d960-4e7a-8eac-bfb12cd2ac1d",
    "metadata": {},
    "outputs": [
@@ -420,7 +421,7 @@
        "4  /Users/katewetstone/Repos/cloud-cover-challeng...  "
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -442,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "c7658707-af2e-4e4f-8658-097ea39338e6",
    "metadata": {},
    "outputs": [
@@ -461,7 +462,7 @@
        "Name: 5703, dtype: object"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -481,17 +482,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "4c1e35de-0c7d-4d9a-8311-a8e32bf79ebd",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x14113cf10>"
+       "<matplotlib.image.AxesImage at 0x14f56a070>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -532,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "6398e03d-0323-4bd8-80f5-af67a9c2b64d",
    "metadata": {},
    "outputs": [],
@@ -548,8 +549,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f125f57f-dd59-483f-8106-c4a587b3836d",
+   "metadata": {},
+   "source": [
+    "**Query for the matching STAC item**"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "42f2c060-8045-4b8f-a66a-579f6bf40b04",
    "metadata": {},
    "outputs": [
@@ -564,7 +573,7 @@
        "   [25.88589523290886, -10.753046965652661]]]}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -589,7 +598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "8cd16663-c5e7-4bd2-abcc-777c618c166f",
    "metadata": {},
    "outputs": [
@@ -617,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "c68c8d39-c13a-4798-b77a-c94a9668027c",
    "metadata": {},
    "outputs": [
@@ -651,10 +660,74 @@
   },
   {
    "cell_type": "markdown",
+   "id": "39b125c3-7b55-476d-a591-4a41932860b6",
+   "metadata": {},
+   "source": [
+    "**Find the best match**\n",
+    "\n",
+    "Sentinel-2 imagery is scanned over a period of time, not captured instantaneously. Timestamps are recorded based on the period of time it took to scan a larger area than the specific chip, called a \"tile\". \n",
+    "\n",
+    "The STAC item and our competition chip have slightly different timestamps because they apply different calculations to the time period when a larger tile was being scanned. \n",
+    "\n",
+    "- The competition chip uses `SENSING_TIME`, the average of the sensing time range.\n",
+    "- STAC items use `PRODUCT_START_TIME`, when the sensing began.\n",
+    "\n",
+    "In this case only one result was returned, so we don't need to worry about whether it's the right item. If multiple results match the query time range, we can pull in the `SENSING_TIME` metadata property of the STAC items to find the best match. The granular metadata of each item is provided in XML format, so we'll use a library called [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) to parse it. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "d0c5997c-b4ce-49d9-b994-f58e1489a6e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "09531931-dc8b-470b-a830-5e564c34b6b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Item sensing time:\t 2020-04-30 08:43:07.181525+00:00\n",
+      "Chip timestamp:\t\t 2020-04-30 08:43:07+00:00\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load the STAC item's granular metadata\n",
+    "granule_metadata_href = pc.sign(item.assets[\"granule-metadata\"].href)\n",
+    "granule_metadata = requests.get(granule_metadata_href)\n",
+    "\n",
+    "# Parse the granular metadata to find SENSING_TIME\n",
+    "soup = BeautifulSoup(granule_metadata.text)\n",
+    "item_sensing_time = pd.to_datetime(soup.find(\"sensing_time\").text)\n",
+    "print(\"Item sensing time:\\t\", item_sensing_time)\n",
+    "print(\"Chip timestamp:\\t\\t\", chip_time)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d77f42d-afd4-4b52-b898-ddfa4ad4325d",
+   "metadata": {},
+   "source": [
+    "We have an exact match! \n",
+    "\n",
+    "For chips where we don't find a perfect match, we'll choose the result that has the maximum geographic overlap with our competition chip. If multiple results have equal overlap, we'll take the one with the closest sensing time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c6a9fbde-9574-4d45-ac01-0e1c5903531f",
    "metadata": {},
    "source": [
-    "In this case only one result was returned, but there's a chance that multiple results will match the query time range. In that case, we'll choose the result that has the maximum geographic overlap with our competition chip. If multiple results have equal overlap, we'll take the one with the closest timestamp.\n",
+    "**Crop the scene**\n",
     "\n",
     "The STAC API hosts Sentinel-2 \"scenes\" which are much larger than individual chips, so we'll need to crop the result to the spatial extent of our chip.\n",
     "\n",
@@ -663,7 +736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 21,
    "id": "e0f715a1-d065-4076-b1e5-41e7713c7dc8",
    "metadata": {},
    "outputs": [
@@ -707,7 +780,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 22,
    "id": "024a8661-eda2-4cbb-ae03-2fffe1026802",
    "metadata": {},
    "outputs": [
@@ -750,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 23,
    "id": "36d6a28d-3e66-4f52-b49f-56c3e5b71f3f",
    "metadata": {},
    "outputs": [
@@ -829,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 24,
    "id": "4405daca-cbfb-4fb2-a62d-52a5b041d816",
    "metadata": {},
    "outputs": [],
@@ -846,6 +919,7 @@
     "from pystac_client import Client\n",
     "import shapely.geometry\n",
     "import rasterio\n",
+    "import requests\n",
     "import rioxarray\n",
     "\n",
     "DATETIME_FORMAT = \"%Y-%m-%dT%H:%M:%SZ\"\n",
@@ -870,12 +944,30 @@
     "        timestamp (datetime.timestamp): timestamp for the original chip to be matched\n",
     "\n",
     "    Returns:\n",
-    "        pystac.item.Item: PySTAC item with the maximum geographic overlap to the\n",
-    "            original chip to be matched. If multiple items have equal overlap, the\n",
-    "            item with the closest timestamp is returned.\n",
+    "        pystac.item.Item: PySTAC item with the closest timestamp and/or maximum\n",
+    "            geographic overlap to the original chip to be matched.\n",
     "    \"\"\"\n",
-    "    # Convert consumable iterators to lists\n",
-    "    items = list(items)\n",
+    "    if len(items) == 1:\n",
+    "        return items[0]\n",
+    "\n",
+    "    # Check for exactly matching timestamp (to the minute) with sensing_time\n",
+    "    sensing_times = []\n",
+    "    for item in items:\n",
+    "        granule_metadata_href = pc.sign(item.assets[\"granule-metadata\"].href)\n",
+    "        granule_metadata = requests.get(granule_metadata_href)\n",
+    "        soup = BeautifulSoup(granule_metadata.text)\n",
+    "        sensing_times.append(\n",
+    "            pd.to_datetime(soup.find(\"sensing_time\").text).round(freq=\"T\")\n",
+    "        )\n",
+    "    exact_timestamp_matches = [\n",
+    "        item\n",
+    "        for item, sensing_time in zip(items, sensing_times)\n",
+    "        if sensing_time == pd.to_datetime(timestamp).round(freq=\"T\")\n",
+    "    ]\n",
+    "\n",
+    "    # If only one item has a perfect match, return it\n",
+    "    if len(exact_timestamp_matches) == 1:\n",
+    "        return exact_timestamp_matches[0]\n",
     "\n",
     "    # Compute overlap between each query result and the geotiff polygon\n",
     "    overlaps = [\n",
@@ -893,16 +985,16 @@
     "    if len(items_overlaps) == 1:\n",
     "        return items_overlaps[0][0]\n",
     "\n",
-    "    # If multiple items have equally high overlap, return the one with the closest timestamp\n",
-    "    min_timedelta = timedelta.max\n",
-    "    best_item = None\n",
-    "    for item, overlap in items_overlaps:\n",
-    "        item_timedelta = abs(item.datetime.astimezone(timestamp.tzinfo) - timestamp)\n",
-    "        if item_timedelta < min_timedelta:\n",
-    "            min_timedelta = item_timedelta\n",
-    "            best_item = item\n",
-    "\n",
-    "    return best_item\n",
+    "    # If multiple items have equally high overlap, return the one with the closest sensing_time\n",
+    "    max_overlap_sensing_times = [\n",
+    "        sensing_time\n",
+    "        for sensing_time, overlap in zip(sensing_times, overlaps)\n",
+    "        if overlap == max_overlap\n",
+    "    ]\n",
+    "    time_deltas = [\n",
+    "        abs(sensing_time - timestamp) for sensing_time in max_overlap_sensing_times\n",
+    "    ]\n",
+    "    return items_overlaps[np.argmin(time_deltas)][0]\n",
     "\n",
     "\n",
     "def query_bands(\n",
@@ -976,12 +1068,13 @@
     "    )\n",
     "\n",
     "    # Filter to the best-matching item\n",
-    "    item = get_closest_item(search.get_items(), area_of_interest, timestamp)\n",
-    "    if item is None:\n",
+    "    items = list(search.get_items())\n",
+    "    if len(items) == 0:\n",
     "        raise ValueError(\n",
     "            \"Query returned no results. Check that the bounding box is correct \"\n",
-    "            \"or try increasing the query time range.\"\n",
+    "            f\"or try increasing the query time range. Chip: {geotiff.name}\"\n",
     "        )\n",
+    "    item = get_closest_item(items, area_of_interest, timestamp)\n",
     "\n",
     "    # Ensure that original chip and PySTAC item have the same coordinate projection\n",
     "    if geotiff.meta[\"crs\"] == item.properties[\"proj:epsg\"]:\n",
@@ -1034,7 +1127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 25,
    "id": "b08f2a05-72bf-4d7d-b5f2-d83a75884127",
    "metadata": {},
    "outputs": [
@@ -1198,7 +1291,7 @@
        "10173  B11_images/xcsb.tif  "
       ]
      },
-     "execution_count": 34,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1219,7 +1312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 28,
    "id": "6aceff68-9665-45bd-866c-8c89beb144f7",
    "metadata": {
     "tags": []
@@ -1229,7 +1322,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████████████████████████| 5/5 [00:08<00:00,  1.78s/it]\n"
+      "100%|█████████████████| 5/5 [00:52<00:00, 10.55s/it]\n"
      ]
     }
    ],
@@ -1260,7 +1353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 29,
    "id": "f8072fb6-e232-4a46-920a-4eefafb512aa",
    "metadata": {},
    "outputs": [

--- a/competitions/cloud-cover/additional-bands-tutorial.ipynb
+++ b/competitions/cloud-cover/additional-bands-tutorial.ipynb
@@ -985,7 +985,7 @@
     "    if len(items_overlaps) == 1:\n",
     "        return items_overlaps[0][0]\n",
     "\n",
-    "    # If multiple items have equally high overlap, return the one with the closest sensing_time\n",
+    "    # If multiple have equally high overlap, return item with closest sensing_time\n",
     "    max_overlap_sensing_times = [\n",
     "        sensing_time\n",
     "        for sensing_time, overlap in zip(sensing_times, overlaps)\n",


### PR DESCRIPTION
Per this discussion [thread](https://community.drivendata.org/t/planetary-computer-train-additional-data-consistency/6905/5), add code to the additional bands tutorial demonstrating how to pull in a STAC item's sensing time for comparison to the competition chip timestamp.