### PR TITLE
Update Binder target to microsoft:main for GDPCIR dataset

### DIFF
--- a/datasets/cil-gdpcir/README.md
+++ b/datasets/cil-gdpcir/README.md
@@ -6,7 +6,7 @@
 
 Try me out on Binder!
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ClimateImpactLab/downscaleCMIP6-binder-env/main?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252FClimateImpactLab%252FPlanetaryComputerExamples%26urlpath%3Dlab%252Ftree%252FPlanetaryComputerExamples%252Fdatasets%252Fcil-gdpcir%252FREADME.md%26branch%3Dgdpcir-additional-notebooks)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ClimateImpactLab/downscaleCMIP6-binder-env/main?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fmicrosoft%252FPlanetaryComputerExamples%26urlpath%3Dlab%252Ftree%252FPlanetaryComputerExamples%252Fdatasets%252Fcil-gdpcir%252FREADME.md%26branch%3Dmain)
 
 These examples cover the [Global Downscaled Projections for Climate Impacts Research (GDPCIR)](https://github.com/ClimateImpactLab/downscaleCMIP6) dataset, produced by the [Climate Impact Lab](https://impactlab.org).
 


### PR DESCRIPTION
Currently the binder button clones the ClimateImpactLab/PlanetaryComputerExamples fork. This updates to point to the mcirosoft repo's main branch. I just tested this by navigating to the URL and the updated link works correctly.

Parsing the components of the link:


```bash
# "launch binder" image
[![Binder](https://mybinder.org/badge_logo.svg)](
    # binder env is a repo we put together with the env alone to minimize build time
    https://mybinder.org/v2/gh/ClimateImpactLab/downscaleCMIP6-binder-env/main?
       # specify git-pull on open
       urlpath=git-pull%3F
            # pull the microsoft/PlanetaryComputerExamples repo
            repo%3Dhttps%253A%252F%252Fgithub.com%252Fmicrosoft%252FPlanetaryComputerExamples%26
            # open jupyterlab
            urlpath%3Dlab%252F
            # open at PlanetaryComputerExamples/datasets/cil-gdpcir/README.md
            tree%252FPlanetaryComputerExamples%252Fdatasets%252Fcil-gdpcir%252FREADME.md%26
            # on branch: main
            branch%3Dmain
)
```
I put this together with the nbgitpuller tool: https://jupyterhub.github.io/nbgitpuller/link?tab=binder