### PR TITLE
Update broken links in Reading STAC tutorial

### DIFF
--- a/quickstarts/reading-stac.ipynb
+++ b/quickstarts/reading-stac.ipynb
@@ -39,7 +39,7 @@
     "\n",
     "We can use the STAC API to search for assets meeting some criteria. This might include the date and time the asset covers, is spatial extent, or any other property captured in the STAC item's metadata.\n",
     "\n",
-    "In this example we'll search for imagery from [Landsat Collection 2 Level-2](https://planetarycomputer.microsoft.com/dataset/landsat-8-c2-l2) area around Microsoft's main campus in December of 2020."
+    "In this example we'll search for imagery from [Landsat Collection 2 Level-2](https://planetarycomputer.microsoft.com/dataset/landsat-c2-l2) area around Microsoft's main campus in December of 2020."
    ]
   },
   {
@@ -1442,7 +1442,7 @@
     "\n",
     "Our `catalog` is a [STAC Catalog](https://github.com/radiantearth/stac-spec/blob/master/catalog-spec/catalog-spec.md) that we can crawl or search. The Catalog contains [STAC Collections](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md) for each dataset we have indexed (which is not the yet the entirity of data hosted by the Planetary Computer).\n",
     "\n",
-    "Collections have information about the [STAC Items](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md) they contain. For instance, here we look at the [Bands](https://github.com/stac-extensions/eo#band-object) available for [Landsat 8 Collection 2 Level 2](https://planetarycomputer.microsoft.com/dataset/landsat-8-c2-l2) data:"
+    "Collections have information about the [STAC Items](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md) they contain. For instance, here we look at the [Bands](https://github.com/stac-extensions/eo#band-object) available for [Landsat 8 Collection 2 Level 2](https://planetarycomputer.microsoft.com/dataset/landsat-c2-l2) data:"
    ]
   },
   {


### PR DESCRIPTION
Found these broken links when browsing the [Reading STAC tutorial](https://planetarycomputer.microsoft.com/docs/quickstarts/reading-stac/).

Update to correct destination:
https://planetarycomputer.microsoft.com/dataset/landsat-c2-l2