### PR TITLE
Change from raster to terra package

### DIFF
--- a/quickstarts/reading-stac-r.ipynb
+++ b/quickstarts/reading-stac-r.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "library(rstac)\n",
     "library(magrittr)\n",
-    "library(raster)\n",
+    "library(terra)\n",
     "\n",
     "s_obj <- stac(\"https://planetarycomputer.microsoft.com/api/stac/v1/\")"
    ]
@@ -136,7 +136,7 @@
    ],
    "source": [
     "url <- paste0(\"/vsicurl/\", it_obj$features[[1]]$assets$SR_B2$href)\n",
-    "data <- raster(url)\n",
+    "data <- rast(url)\n",
     "plot(data)"
    ]
   },


### PR DESCRIPTION
L33 changed to terra (https://github.com/rspatial/terra) since it replaces raster package 
L139 changed to rast() from raster() using terra function