### PR TITLE
remove binder badge pointing to Climate Impact Lab repo

### DIFF
--- a/datasets/cil-gdpcir/cil-gdpcir-example.ipynb
+++ b/datasets/cil-gdpcir/cil-gdpcir-example.ipynb
@@ -11,11 +11,7 @@
     "\n",
     "See the project homepage for more information: [github.com/ClimateImpactLab/downscaleCMIP6](https://github.com/ClimateImpactLab/downscaleCMIP6).\n",
     "\n",
-    "This tutorial covers accessing the STAC API to explore the collections and open a dataset. Additional tutorials are available at [github.com/microsoft/PlanetaryComputerExamples](https://github.com/microsoft/PlanetaryComputerExamples/blob/main/datasets/cil-gdpcir).\n",
-    "\n",
-    "Try it live on Binder:\n",
-    "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ClimateImpactLab/downscaleCMIP6-binder-env/main?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252FClimateImpactLab%252FPlanetaryComputerExamples%26urlpath%3Dlab%252Ftree%252FPlanetaryComputerExamples%252Fdatasets%252Fcil-gdpcir%252Fcil-gdpcir-example.ipynb%26branch%3Dgdpcir-additional-notebooks)"
+    "This tutorial covers accessing the STAC API to explore the collections and open a dataset. Additional tutorials are available at [github.com/microsoft/PlanetaryComputerExamples](https://github.com/microsoft/PlanetaryComputerExamples/blob/main/datasets/cil-gdpcir).\n"
    ]
   },
   {


### PR DESCRIPTION
There is currently a binder badge still pointing to the Climate Impact Lab fork of this repo - sorry for the miss!

This just removes the binder badge from this notebook. There is still a binder badge on the dataset README.md file in this directory, but it correctly points to the https://github.com/microsoft/PlanetaryComputerExamples repo. The reference to https://github.com/ClimateImpactLab/downscaleCMIP6-binder-env simply specifies the build environment for binder - the repo is specified by the `?urlpath=git-pull` arguments.

@TomAugspurger 