### PR TITLE
add diff github action

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - staging
   pull_request:
     branches:
       - main
-      - staging
 
 permissions:
   contents: read

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,0 +1,36 @@
+name: git diff with nbdime
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+  pull_request:
+    branches:
+      - main
+      - staging
+
+permissions:
+  contents: read
+
+jobs:
+  diffs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9.13"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install nbdime ipython_genutils
+    - name: Configure nbdime
+      run: |
+        /opt/hostedtoolcache/Python/3.9.13/x64/bin/nbdime config-git --enable --global
+    - name: git diff
+      run: |
+        git diff HEAD^ HEAD


### PR DESCRIPTION
Following the comment here (https://github.com/microsoft/PlanetaryComputerExamples/issues/213#issuecomment-1226649498). I'm exploring the option git diff via nbdime (https://nbdime.readthedocs.io/en/latest/) via a GitHub Action (https://github.com/microsoft/PlanetaryComputerExamples/issues/213#issuecomment-1226649498).

I tinkered with this here: https://github.com/raybellwaves/nbdime_gha_test and was able to get output like below (https://github.com/raybellwaves/nbdime_gha_test/runs/8007629615?check_suite_focus=true - click on git diff to expand).

![Screen Shot 2022-08-24 at 10 17 51 PM](https://user-images.githubusercontent.com/17162724/186561295-e97509f7-349e-4c0a-b151-9be7c001ccca.png)

No idea ~~how slow this will be or~~ (was fast enough in this PR) if it'll be any use but happy to take feedback nonetheless.
