### PR TITLE
Updated radiant-mlhub API docs link

### DIFF
--- a/tutorials/radiant-mlhub-landcovernet.ipynb
+++ b/tutorials/radiant-mlhub-landcovernet.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "<img src='https://radiant-assets.s3-us-west-2.amazonaws.com/PrimaryRadiantMLHubLogo.png' alt='Radiant MLHub Logo' width='300'/>\n",
     "\n",
-    "This Jupyter notebook, which you may copy and adapt for any use, shows basic examples of how to use the API to download labels and source imagery for the LandCoverNet dataset. Full documentation for the API is available at [docs.mlhub.earth](http://docs.mlhub.earth).\n",
+    "This Jupyter notebook, which you may copy and adapt for any use, shows basic examples of how to use the API to download labels and source imagery for the LandCoverNet dataset. Full documentation for the API is available at [mlhub.earth/docs](https://mlhub.earth/docs).\n",
     "\n",
     "We'll show you how to set up your authorization, list collection properties, and retrieve the items (the data contained within them) from those collections.\n",
     "\n",


### PR DESCRIPTION
Old URL is only displaying the REST API Docs. This update is to link to both the `radiant-mlhub` python client docs and the REST API docs.

Existing Old Link:
Full documentation for the API is available at [docs.mlhub.earth](docs.mlhub.earth).

New Link:
Full documentation for the API is available at [mlhub.earth/docs](https://mlhub.earth/docs).