### PR TITLE
Patch radiant-mlhub-landcovernet tutorial

### DIFF
--- a/tutorials/radiant-mlhub-landcovernet.ipynb
+++ b/tutorials/radiant-mlhub-landcovernet.ipynb
@@ -39,14 +39,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stdin",
      "output_type": "stream",
      "text": [
-      "MLHub API Key:  ································································\n"
+      "MLHub API Key:  ········\n"
      ]
     }
    ],
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,14 +120,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Description: LandCoverNet Labels\n",
+      "Description: LandCoverNet Africa Labels\n",
       "License: CC-BY-4.0\n",
       "DOI: 10.34911/rdnt.d2ce8i\n",
       "Citation: Alemohammad S.H., Ballantyne A., Bromberg Gaber Y., Booth K., Nakanuku-Diggs L., & Miglarese A.H. (2020) \"LandCoverNet: A Global Land Cover Classification Training Dataset\", Version 1.0, Radiant MLHub. [Date Accessed] https://doi.org/10.34911/rdnt.d2ce8i\n"
@@ -135,7 +135,7 @@
     }
    ],
    "source": [
-    "collection_id = \"ref_landcovernet_v1_labels\"\n",
+    "collection_id = \"ref_landcovernet_af_v1_labels\"\n",
     "\n",
     "collection = client.get_collection(collection_id)\n",
     "collection_sci_ext = ScientificExtension.ext(collection)\n",
@@ -151,27 +151,27 @@
    "source": [
     "### Finding Possible Land Cover Labels\n",
     "\n",
-    "Each label item within the collection has a property which lists all of the possible land cover types and which ones are present in each label item. The code below prints out which land cover types are present in the dataset and we will reference these later in the notebook when we filter downloads."
+    "Each collection item has a property which lists all of the possible land cover types in the dataset and which ones are present in the current item.\n",
+    "The code below prints out those land cover types present in the dataset and we will reference these later in the notebook when we filter downloads."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Classes for labels\n",
-      "- (Semi) Natural Vegetation\n",
-      "- Artificial Bareground\n",
-      "- Cultivated Vegetation\n",
-      "- Natural Bareground\n",
-      "- No Data\n",
-      "- Permanent Snow/Ice\n",
-      "- Water\n",
-      "- Woody Vegetation\n"
+      "0: No Data\n",
+      "1: Water\n",
+      "2: Artificial Bareground\n",
+      "3: Natural Bareground\n",
+      "4: Permanent Snow/Ice\n",
+      "5: Woody Vegetation\n",
+      "6: Cultivated Vegetation\n",
+      "7: (Semi) Natural Vegetation\n"
      ]
     }
    ],
@@ -179,13 +179,13 @@
     "item_search = client.search(collections=[collection_id])\n",
     "\n",
     "first_item = next(item_search.get_items())\n",
-    "first_item_label_ext = LabelExtension.ext(first_item)\n",
+    "labels_asset = first_item.get_assets()['labels']\n",
+    "classification_labels = labels_asset.to_dict()['file:values']\n",
     "\n",
-    "label_classes = first_item_label_ext.label_classes\n",
-    "for label_class in label_classes:\n",
-    "    print(f\"Classes for {label_class.name}\")\n",
-    "    for c in sorted(label_class.classes):\n",
-    "        print(f\"- {c}\")"
+    "for cl in classification_labels:\n",
+    "    classification_id = cl['value'][0]\n",
+    "    classification_label = cl['summary']\n",
+    "    print(f\"{classification_id}: {classification_label}\")"
    ]
   },
   {
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,27 +214,23 @@
    "source": [
     "#### Downloading Labels\n",
     "\n",
-    "Next, we search for Items in our collection and inspect the `\"label:classes\"` property to find one that contains `\"Woody Vegetation\"`."
+    "Next, we search for Items in our collection and inspect the `\"label:overviews\"` property to find an item that contains `\"Woody Vegetation\"`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Item ID: ref_landcovernet_v1_labels_38PKT_29\n",
-      "Classes:\n",
-      "- No Data\n",
-      "- Water\n",
+      "Item ID: ref_landcovernet_af_v1_labels_38PKT_29\n",
+      "Classification labels:\n",
       "- Artificial Bareground\n",
       "- Natural Bareground\n",
-      "- Permanent Snow/Ice\n",
       "- Woody Vegetation\n",
-      "- Cultivated Vegetation\n",
       "- (Semi) Natural Vegetation\n",
       "Assets:\n",
       "- labels\n",
@@ -245,19 +241,15 @@
    ],
    "source": [
     "for item in item_search.get_items():\n",
-    "    label_ext = LabelExtension.ext(item)\n",
-    "    classes = [\n",
-    "        klass\n",
-    "        for label_class in label_ext.label_classes\n",
-    "        for klass in label_class.classes\n",
-    "    ]\n",
-    "    if \"Woody Vegetation\" in classes:\n",
+    "    labels_count = item.properties['label:overviews'][0]['counts']\n",
+    "    item_labels = [lc['name'] for lc in labels_count]\n",
+    "    if \"Woody Vegetation\" in item_labels:\n",
     "        break\n",
     "\n",
     "print(f\"Item ID: {item.id}\")\n",
-    "print(\"Classes:\")\n",
-    "for klass in classes:\n",
-    "    print(f\"- {klass}\")\n",
+    "print(\"Classification labels:\")\n",
+    "for label in item_labels:\n",
+    "    print(f\"- {label}\")\n",
     "print(\"Assets:\")\n",
     "for asset_key in item.assets.keys():\n",
     "    print(f\"- {asset_key}\")"
@@ -272,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "scrolled": true
    },
@@ -281,7 +273,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading labels from https://api.radiant.earth/mlhub/v1/download/gAAAAABhpmmIxwohP_1GhcdK9xMzxPawSd7gVjC6Cd3RZgplqwJryMeikKRoTsbxyuuotpJmev-nLBKcaiqc2JW9Tq929ec6mzk6XMNWO-o-UTuUI-rsUJ9ObhHzXs5ZmhytZtq0bN0QdOihlzGXQGBNJB1lbaYx1r-nQGE8VjIeSCARhvjZSwhVHrLX1iJ1bSF8Ea9eerFmsXwKvynAC44-MB4C-A2-qXyw2mx9FGpaUWSvBk15fApnEvMUBTa2cImDSHFq4p1VRt413iYonPqs9P7Zr2STVQ==\n"
+      "Downloading labels from https://api.radiant.earth/mlhub/v1/download/gAAAAABjkjvZqxDgYO2BPkIozpU4883Ka8zTLJY3A9tFIzPOTrI5RzX30f39lBZGrGnpypnRyayQwQSZlNXGYr-XuYq5d39xNyMZLruOZE0v9p3HXIcfMYPBKHOOATdXMF5aB10s6b-JSKkshhkgy4v8meZHuJc7YTdHGeDKIwL18Z6HwkMBpzMDNwQbvm87ikYBguUSwXJs-FfbP-ykEwrafHMJroGK2eRuMtTYVhOGKpC9XD1l-t_CZVTLrahcLXiZ4eXjcOixRb1XNSSE1JDK2t8D-MGJacrm5uhS-xFQPPEUtEtnu9U=\n"
      ]
     }
    ],
@@ -306,24 +298,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Source Imagery Links: 72\n",
-      "- http://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_v1_source/items/ref_landcovernet_v1_source_38PKT_29_20180101\n",
-      "- http://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_v1_source/items/ref_landcovernet_v1_source_38PKT_29_20180106\n",
-      "- http://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_v1_source/items/ref_landcovernet_v1_source_38PKT_29_20180111\n",
-      "- http://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_v1_source/items/ref_landcovernet_v1_source_38PKT_29_20180116\n",
-      "- http://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_v1_source/items/ref_landcovernet_v1_source_38PKT_29_20180121\n",
-      "- http://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_v1_source/items/ref_landcovernet_v1_source_38PKT_29_20180126\n",
-      "- http://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_v1_source/items/ref_landcovernet_v1_source_38PKT_29_20180131\n",
-      "- http://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_v1_source/items/ref_landcovernet_v1_source_38PKT_29_20180205\n",
-      "- http://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_v1_source/items/ref_landcovernet_v1_source_38PKT_29_20180210\n",
-      "- http://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_v1_source/items/ref_landcovernet_v1_source_38PKT_29_20180215\n",
+      "Source Imagery Links: 167\n",
+      "- https://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_af_v1_source_sentinel_2/items/ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180101\n",
+      "- https://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_af_v1_source_sentinel_2/items/ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180106\n",
+      "- https://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_af_v1_source_sentinel_2/items/ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180111\n",
+      "- https://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_af_v1_source_sentinel_2/items/ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180116\n",
+      "- https://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_af_v1_source_sentinel_2/items/ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180121\n",
+      "- https://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_af_v1_source_sentinel_2/items/ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180126\n",
+      "- https://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_af_v1_source_sentinel_2/items/ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180131\n",
+      "- https://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_af_v1_source_sentinel_2/items/ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180205\n",
+      "- https://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_af_v1_source_sentinel_2/items/ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180210\n",
+      "- https://api.radiant.earth/mlhub/v1/collections/ref_landcovernet_af_v1_source_sentinel_2/items/ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180215\n",
       "...\n"
      ]
     }
@@ -342,19 +334,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that there are 72 different source images that can be associated with these labels. Let's grab the STAC Item for the first one so we can download the RGB band assets for that image. Because the Radiant MLHub API requires authentication to retrieve Items, we cannot use the standard PySTAC methods for resolving STAC Objects. Instead, we will use the custom `requests.Session` instance we created above."
+    "We can see that there are 167 different source images that can be associated with these labels. Let's grab the STAC Item for the first one so we can download the RGB band assets for that image. Because the Radiant MLHub API requires authentication to retrieve Items, we cannot use the standard PySTAC methods for resolving STAC Objects. Instead, we will use the custom `requests.Session` instance we created above."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Item ID: ref_landcovernet_v1_source_38PKT_29_20180101\n",
+      "Item ID: ref_landcovernet_af_v1_source_sentinel_2_38PKT_29_20180101\n",
       "Assets:\n",
       "- Asset Key: B01\n",
       "  Bands:Coastal Aerosol\n",
@@ -412,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,16 +425,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['image-B02', 'image-B04', 'labels.tif', 'image-B03']"
+       "['image-B02', 'labels.tif', 'image-B03', 'image-B04']"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -462,19 +454,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'collection': 'ref_landcovernet_v1_labels',\n",
-       " 'dataset': 'landcovernet_v1',\n",
-       " 'size': 19205520,\n",
+       "{'collection': 'ref_landcovernet_af_v1_labels',\n",
+       " 'dataset': 'ref_landcovernet_af_v1',\n",
+       " 'size': 20684609,\n",
        " 'types': ['labels']}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -486,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,7 +497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -513,7 +505,7 @@
      "output_type": "stream",
      "text": [
       "Archive Exists?: True\n",
-      "Archive Size: 19205520\n"
+      "Archive Size: 20684609\n"
      ]
     }
    ],
@@ -541,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -565,7 +557,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/tutorials/radiant-mlhub-landcovernet.ipynb
+++ b/tutorials/radiant-mlhub-landcovernet.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "from pystac import Item\n",
     "from pystac.extensions.eo import EOExtension\n",
-    "from pystac.extensions.label import LabelExtension, LabelRelType\n",
+    "from pystac.extensions.label import LabelRelType\n",
     "from pystac.extensions.scientific import ScientificExtension\n",
     "from pystac_client import Client\n",
     "\n",
@@ -151,7 +151,7 @@
    "source": [
     "### Finding Possible Land Cover Labels\n",
     "\n",
-    "Each collection item has a property which lists all of the possible land cover types in the dataset and which ones are present in the current item.\n",
+    "Each item has a property which lists all of the possible land cover types in the dataset and which ones are present in the current item.\n",
     "The code below prints out those land cover types present in the dataset and we will reference these later in the notebook when we filter downloads."
    ]
   },
@@ -179,12 +179,12 @@
     "item_search = client.search(collections=[collection_id])\n",
     "\n",
     "first_item = next(item_search.get_items())\n",
-    "labels_asset = first_item.get_assets()['labels']\n",
-    "classification_labels = labels_asset.to_dict()['file:values']\n",
+    "labels_asset = first_item.get_assets()[\"labels\"]\n",
+    "classification_labels = labels_asset.to_dict()[\"file:values\"]\n",
     "\n",
     "for cl in classification_labels:\n",
-    "    classification_id = cl['value'][0]\n",
-    "    classification_label = cl['summary']\n",
+    "    classification_id = cl[\"value\"][0]\n",
+    "    classification_label = cl[\"summary\"]\n",
     "    print(f\"{classification_id}: {classification_label}\")"
    ]
   },
@@ -241,8 +241,8 @@
    ],
    "source": [
     "for item in item_search.get_items():\n",
-    "    labels_count = item.properties['label:overviews'][0]['counts']\n",
-    "    item_labels = [lc['name'] for lc in labels_count]\n",
+    "    labels_count = item.properties[\"label:overviews\"][0][\"counts\"]\n",
+    "    item_labels = [lc[\"name\"] for lc in labels_count]\n",
     "    if \"Woody Vegetation\" in item_labels:\n",
     "        break\n",
     "\n",


### PR DESCRIPTION
Bug:
- Land Cover Net global dataset is no longer available

Fix:
- Use the Land Cover Net Africa dataset instead

Changes:
- Had to drop the use of `pystac.extensions.label.LabelExtension` in favor of accessing the labels as JSONs
- Made some content adjustments in order to reflect the current changes