### PR TITLE
Update sentinel-1-grd-example.ipynb

### DIFF
--- a/datasets/sentinel-1-grd/sentinel-1-grd-example.ipynb
+++ b/datasets/sentinel-1-grd/sentinel-1-grd-example.ipynb
@@ -125,7 +125,7 @@
     "from IPython.display import Image\n",
     "\n",
     "item = items[0]\n",
-    "Image(url=item.assets[\"rendered_preview\"].href)"
+    "Image(url=item.assets[\"thumbnail\"].href)"
    ]
   },
   {


### PR DESCRIPTION
item.assets["rendered_preview"] not showing a preview. Substituted by item.assets["thumbnail"] seems to work