### PR TITLE
Docs add odc stac quickstart

### DIFF
--- a/quickstarts/odc-stac.ipynb
+++ b/quickstarts/odc-stac.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Building an analysis-ready data cube from Planetary Computer STAC",
+    "",
+    "A STAC search returns item metadata: hrefs, dates, cloud cover. Analysis usually wants something else, a single aligned array indexed by time, band, and space, that you can run math across. Two libraries build that cube from STAC items: [odc-stac](https://odc-stac.readthedocs.io/) and [stackstac](https://stackstac.readthedocs.io/). They take the same inputs and produce lazy, Dask-backed xarray objects, but they differ in ways that matter on Planetary Computer data.",
+    "",
+    "This notebook loads a few low-cloud [Sentinel-2 L2A](https://planetarycomputer.microsoft.com/dataset/sentinel-2-l2a) scenes over Portland with both libraries and compares them. The companion [data cube tutorial](../overview/odc-stac.md) has the full narrative."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet odc-stac stackstac pystac-client planetary-computer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Search the catalog",
+    "",
+    "Open the catalog with the Planetary Computer signer so every returned asset href is signed, then search for a few low-cloud Sentinel-2 scenes over Portland.",
+    "",
+    "**Expected result:** up to four signed Sentinel-2 items."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pystac_client\n",
+    "import planetary_computer\n",
+    "\n",
+    "catalog = pystac_client.Client.open(\n",
+    "    \"https://planetarycomputer.microsoft.com/api/stac/v1\",\n",
+    "    modifier=planetary_computer.sign_inplace,\n",
+    ")\n",
+    "items = list(catalog.search(\n",
+    "    collections=[\"sentinel-2-l2a\"],\n",
+    "    bbox=[-122.7, 45.5, -122.6, 45.6],\n",
+    "    datetime=\"2024-07-01/2024-08-01\",\n",
+    "    query={\"eo:cloud_cover\": {\"lt\": 20}},\n",
+    "    max_items=4,\n",
+    ").items())\n",
+    "len(items)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load with odc-stac",
+    "",
+    "`odc.stac.load` reads the items into an `xarray.Dataset`, one named variable per band. It infers the coordinate reference system and resolution from the STAC metadata, so you only specify what you want to change. The bands arrive as separate `data_vars` (reference them by name, `cube.B04`) and values come back as `float32`.",
+    "",
+    "**Expected result:** an `xarray.Dataset`, dims `(time, y, x)`, bands `B04`/`B03`/`B02` as `float32`, CRS `EPSG:32610` inferred automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import odc.stac\n",
+    "\n",
+    "cube = odc.stac.load(\n",
+    "    items,\n",
+    "    bands=[\"B04\", \"B03\", \"B02\"],\n",
+    "    bbox=[-122.7, 45.5, -122.6, 45.6],\n",
+    "    resolution=10,\n",
+    "    chunks={\"time\": 1, \"x\": 1024, \"y\": 1024},\n",
+    ")\n",
+    "cube"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load with stackstac",
+    "",
+    "`stackstac.stack` produces a single `xarray.DataArray` with a `band` dimension instead of named variables. On Planetary Computer Sentinel-2 it needs one thing odc-stac did not: an explicit CRS. Without `epsg=`, the call raises `Cannot pick a common CRS, since asset 'B04' ... does not have one`, because the Planetary Computer's Sentinel-2 items do not expose a per-asset CRS that stackstac can infer. In exchange, stackstac attaches every STAC item property to the cube as a coordinate.",
+    "",
+    "**Expected result:** an `xarray.DataArray`, dims `(time, band, y, x)`, `float64`, with item properties attached as coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import stackstac\n",
+    "\n",
+    "cube = stackstac.stack(\n",
+    "    items,\n",
+    "    assets=[\"B04\", \"B03\", \"B02\"],\n",
+    "    bounds_latlon=[-122.7, 45.5, -122.6, 45.6],\n",
+    "    resolution=10,\n",
+    "    epsg=32610,        # required: see above\n",
+    "    chunksize=1024,\n",
+    ")\n",
+    "cube"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How they compare",
+    "",
+    "| | odc-stac | stackstac |",
+    "|---|---|---|",
+    "| CRS on PC Sentinel-2 | inferred automatically | must pass `epsg=` |",
+    "| Shape | `Dataset`, named bands, dims `(time, y, x)` | `DataArray`, `band` dim, dims `(time, band, y, x)` |",
+    "| dtype | `float32` | `float64` (twice the memory) |",
+    "| STAC metadata | not attached | every item property as a coordinate |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A recommendation",
+    "",
+    "For Planetary Computer work, odc-stac is the smoother default. It infers the CRS, returns named bands, and uses `float32`, which halves memory before you have done anything. stackstac earns its place when you want the full STAC metadata riding along on the cube as coordinates, or when you already have stackstac code and a single `DataArray` fits your pipeline.",
+    "",
+    "Migrating a stackstac call to odc-stac is mostly renaming: `assets` becomes `bands`, `bounds_latlon` becomes `bbox`, and you can drop the `epsg=` argument. Reference bands by name afterward rather than selecting along a `band` dimension."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## When to use something else",
+    "",
+    "A cube is the right shape for time-series and multi-band analysis across an area. When you only need pixels from a single scene, the cube machinery is overhead; read the window directly with [async-geotiff](../overview/async-geotiff.md) instead."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/quickstarts/odc-stac.ipynb
+++ b/quickstarts/odc-stac.ipynb
@@ -6,9 +6,17 @@
    "source": [
     "# Building an analysis-ready data cube from Planetary Computer STAC",
     "",
-    "A STAC search returns item metadata: hrefs, dates, cloud cover. Analysis usually wants something else, a single aligned array indexed by time, band, and space, that you can run math across. Two libraries build that cube from STAC items: [odc-stac](https://odc-stac.readthedocs.io/) and [stackstac](https://stackstac.readthedocs.io/). They take the same inputs and produce lazy, Dask-backed xarray objects, but they differ in ways that matter on Planetary Computer data.",
+    "A STAC search returns item metadata: hrefs, dates, cloud cover. Analysis usually wants something else: a single aligned array indexed by time, band, and space that you can run math across. This notebook builds that cube two ways, with [odc-stac](https://odc-stac.readthedocs.io/) and [stackstac](https://stackstac.readthedocs.io/). Key benefits:",
     "",
-    "This notebook loads a few low-cloud [Sentinel-2 L2A](https://planetarycomputer.microsoft.com/dataset/sentinel-2-l2a) scenes over Portland with both libraries and compares them. The companion [data cube tutorial](../overview/odc-stac.md) has the full narrative."
+    "1. **Aligned cube**: turn a pile of STAC items into one array indexed by time, band, and space.",
+    "2. **Lazy and Dask-backed**: the cube builds without reading pixels until you compute.",
+    "3. **CRS handling**: odc-stac infers the projection from STAC metadata; stackstac takes an explicit `epsg=`.",
+    "4. **Two shapes**: odc-stac returns a `Dataset` of named `float32` bands; stackstac returns one `float64` `DataArray` with a `band` dimension and every item property as a coordinate.",
+    "5. **Same inputs**: both take the same signed STAC items, so you can pick per pipeline.",
+    "",
+    "We'll load a few low-cloud [Sentinel-2 L2A](https://planetarycomputer.microsoft.com/dataset/sentinel-2-l2a) scenes over Portland, Oregon with both libraries and compare CRS handling, shape, dtype, and metadata.",
+    "",
+    "The companion [data cube tutorial](../overview/odc-stac.md) has the full narrative."
    ]
   },
   {
@@ -149,9 +157,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## When to use something else",
+    "## You're done",
     "",
-    "A cube is the right shape for time-series and multi-band analysis across an area. When you only need pixels from a single scene, the cube machinery is overhead; read the window directly with [async-geotiff](../overview/async-geotiff.md) instead."
+    "If both load cells built a cube, you turned four Sentinel-2 scenes into an analysis-ready array two ways: odc-stac's named `float32` `Dataset` and stackstac's `float64` `DataArray` with metadata as coordinates.",
+    "",
+    "Swap in your own bbox, collection, or band list and the same load applies. When you only need pixels from a single scene rather than a cube, the cube machinery is overhead; read the window directly with the [async-geotiff tutorial](../overview/async-geotiff.md) instead."
    ]
   }
  ],


### PR DESCRIPTION
Draft odc-stac quickstart notebook: build a Sentinel-2 data cube two ways and compare CRS, shape, and dtype.

Related to tutorial pr here: https://github.com/microsoft/PlanetaryComputerDataCatalog/pull/535